### PR TITLE
Stop trying to read if no inputs are connected

### DIFF
--- a/lib/mixer.js
+++ b/lib/mixer.js
@@ -73,7 +73,9 @@ Mixer.prototype._read = function() {
 
 		this.push(mixedBuffer);
 	} else {
-		setImmediate(this._read.bind(this));
+		if (this.inputs.length){
+			setImmediate(this._read.bind(this));
+		}
 	}
 };
 
@@ -91,6 +93,10 @@ Mixer.prototype.input = function (args) {
 	input.on('finish', () =>{
 		this.inputs.splice(this.inputs.indexOf(input), 1);
 	});
+	
+	if (this.inputs.length === 1){
+		setImmediate(this._read.bind(this));
+	}
 
 	return input;
 };


### PR DESCRIPTION
If no inputs are connected, the `_read` function still keeps looping ( using `setImmediate(this._read.bind(this));` ) to wait for more samples to be available. This can cause the CPU usage to go up (60% on my 2014 MBP) even when no audio is being played.

This fix stops the looping if `this.inputs` array is empty and starts it again when new inputs are connected.